### PR TITLE
Fix IndexOutOfRangeException on both the bundle command if no folder is specified and if no arguments on the program are specified

### DIFF
--- a/LoveBundler/Program.cs
+++ b/LoveBundler/Program.cs
@@ -32,9 +32,16 @@ try
         }
         case "bundle":
         {
-            var command = new BundlerCompileCommand(args[1]);
-            command.Execute();
-            break;
+            if (args.Length < 2 || string.IsNullOrWhiteSpace(args[1]))
+            {
+                Console.WriteLine("Error: Missing directory argument for the 'bundle' command.");
+                Console.WriteLine("Usage: lovebundler bundle <dir>");
+                return;
+            }
+
+             var command = new BundlerCompileCommand(args[1]);
+             command.Execute();
+             break;
         }
         case "-h":
         case "--help":

--- a/LoveBundler/Program.cs
+++ b/LoveBundler/Program.cs
@@ -4,6 +4,20 @@ using LoveBundler;
 using System.Linq;
 using System;
 
+if (args.Length == 0)
+{
+    // Print help text if no argument is specified
+    Console.WriteLine("Usage: lovebundler <command>");
+    Console.WriteLine("Commands:");
+    Console.WriteLine("  convert <files>  Convert media files to the required format");
+    Console.WriteLine("  bundle <dir>     Bundle the game for the specified console");
+    Console.WriteLine();
+    Console.WriteLine("Options:");
+    Console.WriteLine("  -h, --help       Show this help text");
+    Console.WriteLine();
+    return;
+}
+
 var commandSelector = args[0];
 try
 {


### PR DESCRIPTION
Before those commits running the bundle command without an folder argument or running the program without any argument will result in a error like this if ran without arguments: 
`Unhandled exception. System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Program.<Main>$(String[] args)
   at Program.<Main>(String[] args)`
and if ran with bundle argument without a file argument:
`System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Program.<Main>$(String[] args)
Unhandled exception. System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Program.<Main>$(String[] args)
   at Program.<Main>(String[] args)`