### PR TITLE
Add clearer dependency instalation instructions and more clearer errors when fields in the .toml file are missing

### DIFF
--- a/LoveBundler/CompilerSettings.cs
+++ b/LoveBundler/CompilerSettings.cs
@@ -16,21 +16,63 @@ public class CompilerSettings
 
     public CompilerSettings(string toml)
     {
-        var model = Toml.ToModel(toml);
-        this.Title = (string)((TomlTable)model["metadata"])["title"];
-        this.Author = (string)((TomlTable)model["metadata"])["author"];
-        this.Description = (string)((TomlTable)model["metadata"])["description"];
-        this.Version = (string)((TomlTable)model["metadata"])["version"];
-        this.Target = ((TomlArray)((TomlTable)model["build"]!)["targets"]).Select(x => (string)x).ToArray();
-        var tmpIcons = ((TomlTable)((TomlTable)model["metadata"])["icons"]).ToDictionary();
-        this.Icons = new Dictionary<string, string>();
-        foreach (var (key, value) in tmpIcons)
-        {
-            if (string.IsNullOrEmpty(value as string))
-                continue;
-            this.Icons.Add(key, (string)value);
-        }
-    }
+       var model = Toml.ToModel(toml);
+
+        if (!model.ContainsKey("metadata"))
+            throw new Exception("Missing 'metadata' section in the .toml file.");
+
+         var metadata = (TomlTable)model["metadata"];
+         if (!metadata.ContainsKey("title"))
+             throw new Exception("Missing 'title' in the 'metadata' section of the .toml file.");
+         this.Title = (string)metadata["title"];
+
+         if (!metadata.ContainsKey("author"))
+             throw new Exception("Missing 'author' in the 'metadata' section of the .toml file.");
+         this.Author = (string)metadata["author"];
+
+         if (!metadata.ContainsKey("description"))
+             throw new Exception("Missing 'description' in the 'metadata' section of the .toml file.");
+         this.Description = (string)metadata["description"];
+
+         if (!metadata.ContainsKey("version"))
+             throw new Exception("Missing 'version' in the 'metadata' section of the .toml file.");
+         this.Version = (string)metadata["version"];
+
+         if (!model.ContainsKey("build"))
+             throw new Exception("Missing 'build' section in the .toml file.");
+
+         var build = (TomlTable)model["build"];
+         if (!build.ContainsKey("targets"))
+             throw new Exception("Missing 'targets' in the 'build' section of the .toml file.");
+         this.Target = ((TomlArray)build["targets"]).Select(x => (string)x).ToArray();
+
+         if (metadata.ContainsKey("icons"))
+         {
+             var tmpIcons = ((TomlTable)metadata["icons"]).ToDictionary();
+             this.Icons = new Dictionary<string, string>();
+             foreach (var (key, value) in tmpIcons)
+             {
+                 if (!string.IsNullOrEmpty(value as string))
+                     this.Icons.Add(key, (string)value);
+             }
+         }
+         else
+         {
+             this.Icons = new Dictionary<string, string>();
+         }
+
+         // Ensure no critical fields are left empty
+         if (string.IsNullOrWhiteSpace(this.Title))
+             throw new Exception("The 'title' field in 'metadata' cannot be empty.");
+         if (string.IsNullOrWhiteSpace(this.Author))
+             throw new Exception("The 'author' field in 'metadata' cannot be empty.");
+         if (string.IsNullOrWhiteSpace(this.Description))
+             throw new Exception("The 'description' field in 'metadata' cannot be empty.");
+         if (string.IsNullOrWhiteSpace(this.Version))
+             throw new Exception("The 'version' field in 'metadata' cannot be empty.");
+         if (this.Target.Length == 0)
+             throw new Exception("The 'targets' array in 'build' must contain at least one target.");
+     }
 
     /// <summary>
     /// Gets the SMDH command for 3DS compilation

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ sudo (dkp-)pacman -S wut-tools
 ### CLI aproach (traditional method)
 To get devKitPro's pacman repositories refer to the [devkitPro wiki](https://devkitpro.org/wiki/Getting_Started).
 
-Then after installing the devKirPro repositories run these commands on MSYS2:
+Then after installing the devKitPro repositories run these commands on MSYS2:
 ```bash
 sudo (dkp-)pacman -Syu && sudo (dkp-)pacman -S switch-dev 3ds-dev wiiu-dev wut-tools
 ```

--- a/README.md
+++ b/README.md
@@ -4,14 +4,22 @@ LoveBundler is CLI version of bundler tool from Love Potion.
 
 ## Installation
 
-Install devtools
+First install [MSYS2](https://www.msys2.org/) if you are on Windows (skip this step if on Linux) then follow the instructions below:
+## Installing devKitPro development toolkits
 
+### GUI aproach
+
+For a easier aproach if on Windows, use the [GUI tool](https://github.com/devkitPro/installer/releases) and select 3DS Development, Wii Development and Switch Development during the compoment setup which will get most of the utilites installed, then launch MSYS2 and run this command to get wut-tools installed:
 ```bash
-sudo (dkp-)pacman -Syu && sudo (dkp-)pacman -S switch-dev 3ds-dev wiiu-dev
+sudo (dkp-)pacman -S wut-tools
 ```
+### CLI aproach (traditional method)
+To get devKitPro's pacman repositories refer to the [devkitPro wiki](https://devkitpro.org/wiki/Getting_Started).
 
-To get pacman refer to [devkitPro wiki](https://devkitpro.org/wiki/Getting_Started).
-If you already have pacman installed you can customize [existing pacman installation](https://devkitpro.org/wiki/devkitPro_pacman#Customising_Existing_Pacman_Install).
+Then after installing the devKirPro repositories run these commands on MSYS2:
+```bash
+sudo (dkp-)pacman -Syu && sudo (dkp-)pacman -S switch-dev 3ds-dev wiiu-dev wut-tools
+```
 
 ## Usage
 


### PR DESCRIPTION
This should now prevent depedency issues when running this tool if installed using this method.